### PR TITLE
Fix send functions, solve semicolon problem in a different way

### DIFF
--- a/ahk-v1-runner.ahk
+++ b/ahk-v1-runner.ahk
@@ -23,9 +23,21 @@ write(initVars)
 
 SetWorkingDir % RTrim(stdin.ReadLine(), "`n") %
 
+; joins array elements with given separator, starting from given index
+JoinSubArray(sep, start, strings*) {
+  for index,str in strings
+    if (index >= start) {
+      if (index >= start + 1) {
+        str .= sep
+      }
+      str .= str
+    }
+  return str
+}
+
 Loop {
   x := RTrim(stdin.ReadLine(), "`n")
-  data := StrSplit(x, "!;")
+  data := StrSplit(x, ";")
   if (data[1] = "mouseMove") {
     MouseMove data[2], data[3], data[4]
     write("done")
@@ -38,7 +50,7 @@ Loop {
   } else if (data[1] = "getClipboard") {
     write(clipboard)
   } else if (data[1] = "setClipboard") {
-    clipboard := % data[2] %
+    clipboard := % JoinSubArray(";", 2, data) %
     write("done")
   } else if (data[1] = "pixelSearch") {
     PixelSearch x, y, data[2], data[3], data[4], data[5], data[6], [data[7], Fast RGB]
@@ -56,13 +68,13 @@ Loop {
     SetKeyDelay data[2], data[3], % data[4] %
     write("done")
   } else if (data[1] = "send") {
-    Send % data[2] %
+    Send % JoinSubArray(";", 2, data) %
     write("done")
   } else if (data[1] = "sendInput") {
-    SendInput % data[2] %
+    SendInput % JoinSubArray(";", 2, data) %
     write("done")
   } else if (data[1] = "sendPlay") {
-    SendPlay % data[2] %
+    SendPlay % JoinSubArray(";", 2, data) %
     write("done")
   } else if (data[1] = "setMouseSpeed") {
     SetDefaultMouseSpeed % data[2] %

--- a/ahk-v1-runner.ahk
+++ b/ahk-v1-runner.ahk
@@ -25,16 +25,16 @@ SetWorkingDir % RTrim(stdin.ReadLine(), "`n") %
 
 ; joins array elements with given separator, starting from given index
 JoinSubArray(sep, start, strings*) {
-  str := ""
+  out := ""
   for index,str in strings {
     if (index >= start) {
       if (index >= start + 1) {
-        str .= sep
+        out .= sep
       }
-      str .= str
+      out .= str
     }
   }
-  return str
+  return out
 }
 
 Loop {
@@ -52,7 +52,7 @@ Loop {
   } else if (data[1] = "getClipboard") {
     write(clipboard)
   } else if (data[1] = "setClipboard") {
-    clipboard := % JoinSubArray(";", 2, data) %
+    clipboard := % JoinSubArray(";", 2, data*) %
     write("done")
   } else if (data[1] = "pixelSearch") {
     PixelSearch x, y, data[2], data[3], data[4], data[5], data[6], [data[7], Fast RGB]
@@ -70,13 +70,13 @@ Loop {
     SetKeyDelay data[2], data[3], % data[4] %
     write("done")
   } else if (data[1] = "send") {
-    Send % JoinSubArray(";", 2, data) %
+    Send % JoinSubArray(";", 2, data*) %
     write("done")
   } else if (data[1] = "sendInput") {
-    SendInput % JoinSubArray(";", 2, data) %
+    SendInput % JoinSubArray(";", 2, data*) %
     write("done")
   } else if (data[1] = "sendPlay") {
-    SendPlay % JoinSubArray(";", 2, data) %
+    SendPlay % JoinSubArray(";", 2, data*) %
     write("done")
   } else if (data[1] = "setMouseSpeed") {
     SetDefaultMouseSpeed % data[2] %

--- a/ahk-v1-runner.ahk
+++ b/ahk-v1-runner.ahk
@@ -25,13 +25,15 @@ SetWorkingDir % RTrim(stdin.ReadLine(), "`n") %
 
 ; joins array elements with given separator, starting from given index
 JoinSubArray(sep, start, strings*) {
-  for index,str in strings
+  str := ""
+  for index,str in strings {
     if (index >= start) {
       if (index >= start + 1) {
         str .= sep
       }
       str .= str
     }
+  }
   return str
 }
 

--- a/ahk-v2-runner.ahk
+++ b/ahk-v2-runner.ahk
@@ -25,13 +25,15 @@ SetWorkingDir(RTrim(stdin1.ReadLine(), "`n"))
 
 ; joins array elements with given separator, starting from given index
 JoinSubArray(sep, start, strings*) {
-  for index,str in strings
+  str := ""
+  for index,str in strings {
     if (index >= start) {
       if (index >= start + 1) {
         str .= sep
       }
       str .= str
     }
+  }
   return str
 }
 

--- a/ahk-v2-runner.ahk
+++ b/ahk-v2-runner.ahk
@@ -23,9 +23,21 @@ write(initVars)
 
 SetWorkingDir(RTrim(stdin1.ReadLine(), "`n"))
 
+; joins array elements with given separator, starting from given index
+JoinSubArray(sep, start, strings*) {
+  for index,str in strings
+    if (index >= start) {
+      if (index >= start + 1) {
+        str .= sep
+      }
+      str .= str
+    }
+  return str
+}
+
 Loop{
   x := RTrim(stdin1.ReadLine(), "`n")
-  data := StrSplit(x, "!;")
+  data := StrSplit(x, ";")
   if (data[1] = "mouseMove") {
     MouseMove(data[2], data[3], data[4])
     write("done")
@@ -38,7 +50,7 @@ Loop{
   } else if (data[1] = "getClipboard") {
     write(A_Clipboard)
   } else if (data[1] = "setClipboard") {
-    A_Clipboard := data[2]
+    A_Clipboard := JoinSubArray(";", 2, data)
     write("done")
   } else if (data[1] = "pixelSearch") {
     ErrorLevel := !PixelSearch(&x, &y, data[2], data[3], data[4], data[5], data[6], [data[7], "Fast RGB"]) ;V1toV2: Switched from BGR to RGB values
@@ -56,13 +68,13 @@ Loop{
     SetKeyDelay(data[2], data[3], data[4])
     write("done")
   } else if (data[1] = "send") {
-    Send(data[2])
+    Send(JoinSubArray(";", 2, data))
     write("done")
   } else if (data[1] = "sendInput") {
-    SendInput(data[2])
+    SendInput(JoinSubArray(";", 2, data))
     write("done")
   } else if (data[1] = "sendPlay") {
-    SendPlay(data[2])
+    SendPlay(JoinSubArray(";", 2, data))
     write("done")
   } else if (data[1] = "setMouseSpeed") {
     SetDefaultMouseSpeed(data[2])

--- a/ahk-v2-runner.ahk
+++ b/ahk-v2-runner.ahk
@@ -25,16 +25,16 @@ SetWorkingDir(RTrim(stdin1.ReadLine(), "`n"))
 
 ; joins array elements with given separator, starting from given index
 JoinSubArray(sep, start, strings*) {
-  str := ""
+  out := ""
   for index,str in strings {
     if (index >= start) {
       if (index >= start + 1) {
-        str .= sep
+        out .= sep
       }
-      str .= str
+      out .= str
     }
   }
-  return str
+  return out
 }
 
 Loop{
@@ -52,7 +52,7 @@ Loop{
   } else if (data[1] = "getClipboard") {
     write(A_Clipboard)
   } else if (data[1] = "setClipboard") {
-    A_Clipboard := JoinSubArray(";", 2, data)
+    A_Clipboard := JoinSubArray(";", 2, data*)
     write("done")
   } else if (data[1] = "pixelSearch") {
     ErrorLevel := !PixelSearch(&x, &y, data[2], data[3], data[4], data[5], data[6], [data[7], "Fast RGB"]) ;V1toV2: Switched from BGR to RGB values
@@ -70,13 +70,14 @@ Loop{
     SetKeyDelay(data[2], data[3], data[4])
     write("done")
   } else if (data[1] = "send") {
-    Send(JoinSubArray(";", 2, data))
+    ; MsgBox(JoinSubArray(";", 2, data))
+    Send(JoinSubArray(";", 2, data*))
     write("done")
   } else if (data[1] = "sendInput") {
-    SendInput(JoinSubArray(";", 2, data))
+    SendInput(JoinSubArray(";", 2, data*))
     write("done")
   } else if (data[1] = "sendPlay") {
-    SendPlay(JoinSubArray(";", 2, data))
+    SendPlay(JoinSubArray(";", 2, data*))
     write("done")
   } else if (data[1] = "setMouseSpeed") {
     SetDefaultMouseSpeed(data[2])

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = async function (path, hotkeysList, options) {
     });
   }
   function formatCmd(...cmdAndArgs) {
-    return `${cmdAndArgs.join('!;')}\n`;
+    return `${cmdAndArgs.join(';')}\n`;
   }
   var current = null;
   const ahk = {
@@ -360,7 +360,7 @@ module.exports = async function (path, hotkeysList, options) {
      */
     async sendGeneric(sendType, x) {
       if (typeof x === 'string') x = { msg: x };
-      var toSend = '';
+      let toSend = '';
       if (x.blind) toSend += '{Blind}';
       toSend += x.msg
         .replace(/!/g, '{!}')
@@ -378,21 +378,21 @@ module.exports = async function (path, hotkeysList, options) {
      * @param {{ msg: string, blind?: boolean, raw?: boolean} | string} x - The string to send
      */
     async send(x) {
-      return sendGeneric('send', x);
+      return ahk.sendGeneric('send', x);
     },
     /**
      * Types out a string using SendInput. Look at documentation for extra information.
-     * @param {{ msg: string, blind?: boolean} | string} x - The string to send
+     * @param {{ msg: string, blind?: boolean, raw?: boolean} | string} x - The string to send
      */
     async sendInput(x) {
-      return sendGeneric('sendInput', x);
+      return ahk.sendGeneric('sendInput', x);
     },
     /**
      * Types out a string using SendPlay. Look at documentation for extra information.
-     * @param {{ msg: string, blind?: boolean} | string} x - The string to send
+     * @param {{ msg: string, blind?: boolean, raw?: boolean} | string} x - The string to send
      */
     async sendPlay(x) {
-      return sendGeneric('sendPlay', x);
+      return ahk.sendGeneric('sendPlay', x);
     },
     /**
      * Sets the default mouse speed for clicks and mouseMove

--- a/index.js
+++ b/index.js
@@ -356,7 +356,7 @@ module.exports = async function (path, hotkeysList, options) {
     /**
      * Types out a string. Look at documentation for extra information.
      * @param {'send' | 'sendInput' | 'sendPlay'} sendType - type of "send" command
-     * @param {{ msg: string, blind?: boolean, raw?: boolean} | string} x - The string to send
+     * @param {{ msg: string, blind?: boolean } | string} x - The string to send
      */
     async sendGeneric(sendType, x) {
       if (typeof x === 'string') x = { msg: x };
@@ -375,21 +375,21 @@ module.exports = async function (path, hotkeysList, options) {
     },
     /**
      * Types out a string. Look at documentation for extra information.
-     * @param {{ msg: string, blind?: boolean, raw?: boolean} | string} x - The string to send
+     * @param {{ msg: string, blind?: boolean } | string} x - The string to send
      */
     async send(x) {
       return ahk.sendGeneric('send', x);
     },
     /**
      * Types out a string using SendInput. Look at documentation for extra information.
-     * @param {{ msg: string, blind?: boolean, raw?: boolean} | string} x - The string to send
+     * @param {{ msg: string, blind?: boolean } | string} x - The string to send
      */
     async sendInput(x) {
       return ahk.sendGeneric('sendInput', x);
     },
     /**
      * Types out a string using SendPlay. Look at documentation for extra information.
-     * @param {{ msg: string, blind?: boolean, raw?: boolean} | string} x - The string to send
+     * @param {{ msg: string, blind?: boolean } | string} x - The string to send
      */
     async sendPlay(x) {
       return ahk.sendGeneric('sendPlay', x);


### PR DESCRIPTION
My previous PR introduced a bug for send functions, making them unusable 😭 This is fixed now.
Also, I solved the problem of semicolon in a different way: instead of having strange `!;` separator, the old `;` separator is used but in functions that expect text as input, after splitting the stdio using `;`, the remaining elements of array are rejoined with `;`.

This way, if `a;b` is a desired text, command sent through stdio is `send;a;b`, initially split into ["send", "a", "b"] but then everything except the first element of this array is rejoined into "a;b" and passed to ahk's "Send" function.